### PR TITLE
Fix indentation

### DIFF
--- a/src/main/workflow/sub-workflows/sub-workflow.xml
+++ b/src/main/workflow/sub-workflows/sub-workflow.xml
@@ -3,9 +3,9 @@
 	
 	<!-- Fork two MapReduce jobs -->
 	<fork name="fork-wordcount">
-        <path start="mr-wordcount-p1" />
-        <path start="mr-wordcount-p2" />
-    </fork>
+		<path start="mr-wordcount-p1" />
+		<path start="mr-wordcount-p2" />
+	</fork>
 	
 	<join name="join-wordcount" to="sub-workflow-end" />
 	


### PR DESCRIPTION
Fixing a mixture of spaces within a tab-indented file; "fork" indentation was confusing.